### PR TITLE
Fixed error after function result was sent to ChatGPT

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,10 +2,10 @@
 
 This the python version of the code as implemented by [Unconventional Coding.](https://github.com/unconv/code-interpreter)
 
-Python CodeInterpreter leverages OpenAI's ChatGPT to interact with Python code seamlessly. It allows users to submit Python code, decide whether to run it, and receive the code's output.
+Python CodeInterpreter leverages OpenAI's ChatGPT to interact with Python code seamlessly. It allows users to submit a prompt and ChatGPT will propose Python code to run. The user can decide whether to run it, and receive the code's output.
 
 ## Features:
-1. **Interactive Python Code Execution**: After entering your Python code, the system will ask if you want to run it. Upon your confirmation, it will be executed.
+1. **Interactive Python Code Execution**: After entering your prompt, the system will ask if you want to run the Python code. Upon your confirmation, it will be executed.
 2. **Integration with ChatGPT**: The system uses a Python implementation of ChatGPT for interactive dialogue.
 3. **Function Handling with OpenAI**: Allows the addition and handling of functions with OpenAI's ChatGPT.
 4. **Modular Design**: Easily extendable with more features.
@@ -30,7 +30,7 @@ Python CodeInterpreter leverages OpenAI's ChatGPT to interact with Python code s
 1. Ensure you have the required libraries installed, such as `requests` and `re`.
 2. Provide your `OPENAI_API_KEY` as an environment variable.
 3. Run the main script to start the Python CodeInterpreter.
-4. Enter Python code and decide whether to execute it based on the prompts.
+4. Enter a prompt and decide whether to execute the code given by ChatGPT.
 
 ```bash
 # Sample Interaction:
@@ -40,7 +40,7 @@ Python CodeInterpreter leverages OpenAI's ChatGPT to interact with Python code s
 ################################################
 
 GPT: Hello! I am the Python CodeInterpreter! What would you like to do?
-You: <Enter Your Python Code>
+You: <Enter Your Prompt Here>
 ```
 
 5. Type "exit", "quit", or "stop" to end the interaction.

--- a/chat_gpt.py
+++ b/chat_gpt.py
@@ -42,10 +42,12 @@ class ChatGPT:
         else:
             self.function_call = {"name": function_name, "arguments": arguments}
 
-    def _add_message(self, role: str, content: Optional[str] = None, function_call: Optional[dict] = None):
+    def _add_message(self, role: str, content: Optional[str] = None, function_call: Optional[dict] = None, function_name: Optional[dict] = None):
         message = {"role": role, "content": content}
         if function_call:
             message["function_call"] = function_call
+        if function_name:
+            message["name"] = function_name
         self.messages.append(message)
         if callable(self.savefunction):
             self.savefunction(message, self.chat_id)
@@ -63,7 +65,7 @@ class ChatGPT:
         self._add_message("assistant", None, {"name": function_name, "arguments": function_arguments})
 
     def fresult(self, function_name: str, function_return_value: str):
-        self._add_message("function", function_return_value, {"name": function_name})
+        self._add_message("function", function_return_value, function_name=function_name)
 
     def response(self, raw_function_response: bool = False):
         fields = {"model": self.model, "messages": self.messages}

--- a/interpreter.py
+++ b/interpreter.py
@@ -60,7 +60,7 @@ print("################################################")
 print("#           Python CodeInterpreter             #")
 print("################################################\n")
 
-print("GPT: Hello! I am the Python CodeInterpreter! What would you like to do?\nYou: ")
+print("GPT: Hello! I am the Python CodeInterpreter! What would you like to do?\nYou: ", end="")
 
 while True:
     message = input_message()
@@ -75,4 +75,4 @@ while True:
 
     # Assuming the Python version of ChatGPT has a method 'umessage' and 'response'
     chatgpt.umessage(message)
-    print("\n\nGPT:", chatgpt.response()['content'], "\nYou: ")
+    print("\n\nGPT:", chatgpt.response()['content'], "\nYou: ", end="")


### PR DESCRIPTION
The function result sent to ChatGPT had the 'function_call' property with the name of the function that was run. Instead it must have a 'name' property with the function name.

Now the script actually works properly.

I also updated some of the formatting of the prompt input. It now has the user text on the same line as "You:"

I also updated the README to refer to a prompt instead of code, since you are not supposed to input code for ChatGPT. Instead, a prompt about what you want to do, and ChatGPT will write the code.